### PR TITLE
[Feat] 온보딩 목표 나중에 설정 및 설정 토글 off 지원

### DIFF
--- a/src/main/java/com/example/moamoa_backend/member/controller/OnboardingController.java
+++ b/src/main/java/com/example/moamoa_backend/member/controller/OnboardingController.java
@@ -10,7 +10,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -69,8 +68,11 @@ public class OnboardingController {
             
             scope로 수정 범위를 지정합니다.
             - ALL: selections 필수, dailyMissionGoal/goalRetention은 선택(null 허용)
+             	   (dailyMissionGoal=null AND goalRetention=null 이면 목표는 변경하지 않음: '나중에 설정' 케이스)
             - INTERESTS: selections 필수
-            - GOAL: dailyMissionGoal/goalRetention 필수(0~5)
+            - GOAL: 
+			 		- OFF: dailyMissionGoal=null, goalRetention=null
+			        - ON/변경: dailyMissionGoal 필수(0~5) + goalRetention 필수
             """
 	)
 	@PatchMapping("/onboarding")

--- a/src/main/java/com/example/moamoa_backend/member/dto/OnboardingPatchRequestDto.java
+++ b/src/main/java/com/example/moamoa_backend/member/dto/OnboardingPatchRequestDto.java
@@ -5,18 +5,13 @@ import java.util.List;
 import com.example.moamoa_backend.member.enums.GoalRetention;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 
 public record OnboardingPatchRequestDto(
 	@Valid
 	List<Selection> selections,   // scope=INTERESTS/ALL에서 사용 (GOAL에서는 null 허용)
 
-	@Min(value = 0, message = "일일 목표는 0~5 사이여야 합니다.")
-	@Max(value = 5, message = "일일 목표는 0~5 사이여야 합니다.")
-	Integer dailyMissionGoal,      // scope=GOAL/ALL에서 사용 (INTERESTS에서는 null 허용)
-
-	GoalRetention goalRetention    // scope=GOAL/ALL에서 사용 (OFF 시 null 허용)
+	Integer dailyMissionGoal,     // 0~5 또는 null(OFF/나중에 설정)
+	GoalRetention goalRetention   // null 가능 (dailyMissionGoal이 null이면 반드시 null이어야 함: 서비스에서 검증)
 ) {
 	public record Selection(
 		Long interestId,            // 대분류 ID (소속 검증에 사용)

--- a/src/main/java/com/example/moamoa_backend/member/service/OnboardingService.java
+++ b/src/main/java/com/example/moamoa_backend/member/service/OnboardingService.java
@@ -56,11 +56,13 @@ public class OnboardingService {
 			case ALL -> {
 				requireSelections(req.selections());              // 관심사 최소 1개 이상 필수
 				validateGoalRangeIfPresent(req.dailyMissionGoal()); // goal은 null 허용, 값이 있으면 범위만 검증
-
 				validateGoalRetentionIfPresent(req.dailyMissionGoal(), req.goalRetention());
 
-				// 목표 설정(즉시 적용 or 다음 주 예약)
-				updateGoalSetting(member, req.dailyMissionGoal(), req.goalRetention(), today);
+				// "나중에 설정": goal 관련 값이 아예 없으면 목표를 건드리지 않는다.
+				if (!(req.dailyMissionGoal() == null && req.goalRetention() == null)) {
+					updateGoalSetting(member, req.dailyMissionGoal(), req.goalRetention(), today);
+				}
+
 				updateMemberInterestsSmartSync(member, req.selections()); // 관심사 Smart Sync 반영
 
 				// 최신 ALL 상태로 응답 (member 재조회 없이)
@@ -72,9 +74,17 @@ public class OnboardingService {
 				yield toOnboardingResponse(loadSelections(memberId), member);
 			}
 			case GOAL -> {
-				requireGoal(req.dailyMissionGoal());      // GOAL scope에서는 null 불가
-				validateGoalRange(req.dailyMissionGoal()); // 0~5 범위 검증
+				// 설정 화면 토글 OFF 지원: dailyMissionGoal == null 이면 OFF 처리
+				if (req.dailyMissionGoal() == null) {
+					validateGoalRetentionIfPresent(null, req.goalRetention());
+					updateGoalSetting(member, null, null, today);
+					yield toOnboardingResponse(loadSelections(memberId), member);
+				}
+
+				// 토글 ON 상태에서 값 변경/저장하는 케이스
+				validateGoalRange(req.dailyMissionGoal());   // 0~5 범위 검증
 				requireGoalRetention(req.goalRetention());
+
 				// 목표 설정(즉시 적용 or 다음 주 예약)
 				updateGoalSetting(member, req.dailyMissionGoal(), req.goalRetention(), today);
 				yield toOnboardingResponse(loadSelections(memberId), member);


### PR DESCRIPTION
## 📌 관련 이슈
- closes #66 

---

## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [ ] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정

---

## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.
- 온보딩(신규 유저)에서 “나중에 설정” 선택 시 목표 관련 값이 null로 전달되더라도 기존 목표 상태를 변경하지 않도록 처리

- 설정 화면에서 목표 설정 토글 ON/OFF를 단일 PATCH(onboarding, scope=GOAL)로 지원하도록 로직 확장 및 API 설명 보강

---

## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.
-PATCH /api/v1/members/me/onboarding?scope=ALL에서 dailyMissionGoal=null && goalRetention=null인 경우 목표 변경을 스킵하여 “나중에 설정” 요구사항 반영

- PATCH ...?scope=GOAL에서

    - OFF: dailyMissionGoal=null, goalRetention=null → 목표 OFF 처리

    - ON/변경: dailyMissionGoal(0~5) + goalRetention 필수 → 목표 설정/변경 처리

- 목표 상태 반영(예약 적용/만료)은 기존대로 요청 시점에 
GoalMaintenanceService.applyGoalStateIfNeeded()로 선반영하여 응답 일관성 유지


---

## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [ ] 엔티티 변경
- [ ] 연관관계 수정
- [ ] 컬럼 추가/삭제
- [ ] QueryDSL / JPQL 수정
- [ ] 마이그레이션 필요 (DDL 변경)

**변경 내용**
- 

---

## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [x] 기존 API 스펙 변경
- [ ] API 삭제





---

## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [x] 없음
- [ ] 있음 → 내용:

---

## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분
- 
-

---

## 📎 참고 자료
ERD, API 문서, Swagger 캡처, 관련 링크 등

---

## ✅ 체크 리스트 

- [ ] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [ ] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 목표 설정에서 ON/OFF/변경 전환 기능 추가

* **버그 수정**
  * 목표 관련 정보가 없을 때 불필요한 업데이트 방지
  * 목표 설정 입력값에 대한 유효성 검사 개선
  * Null 값 처리 로직 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->