### PR TITLE
[Refactor] 홈 팝업 조회 시 불필요한 DB Update 방지 로직 개선

### DIFF
--- a/src/main/java/com/example/moamoa_backend/member/controller/MemberController.java
+++ b/src/main/java/com/example/moamoa_backend/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.example.moamoa_backend.member.controller;
 import com.example.moamoa_backend.global.apiPayload.response.ApiResponse;
 import com.example.moamoa_backend.member.dto.req.MemberReqDto;
 import com.example.moamoa_backend.member.dto.res.MemberResDto;
+import com.example.moamoa_backend.member.enums.SettingValue;
 import com.example.moamoa_backend.member.exception.code.MemberSuccessCode;
 import com.example.moamoa_backend.member.service.MemberService;
 import com.example.moamoa_backend.member.service.MemberSettingService;
@@ -59,16 +60,15 @@ public class MemberController {
         return ApiResponse.onSuccess(MemberSuccessCode.MEMBER_UPDATED, null);
     }
 
-    @Operation(summary = "회원 설정 저장", description = "팝업 노출 여부 등 회원 설정을 저장합니다.")
-    @PostMapping("/settings")
+    @Operation(summary = "팝업 다시 보지 않기 설정", description = "특정 팝업에 대해 다시 보지 않기(NEVER_SHOW) 설정을 저장합니다")
+    @PostMapping("/settings/ban")
     public ApiResponse<Void> saveSetting(
             @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody MemberReqDto.SettingRequest request
     ) {
-        memberSettingService.saveSetting(
+        memberSettingService.banPopup(
                 Long.parseLong(userDetails.getUsername()),
-                request.settingKey(),
-                request.settingValue()
+                request.settingKey()
         );
         return ApiResponse.onSuccess(MemberSuccessCode.SETTING_SAVED, null);
     }

--- a/src/main/java/com/example/moamoa_backend/member/dto/req/MemberReqDto.java
+++ b/src/main/java/com/example/moamoa_backend/member/dto/req/MemberReqDto.java
@@ -37,12 +37,8 @@ public class MemberReqDto {
     ) {}
 
     public record SettingRequest(
-
             @NotBlank(message = "설정 키는 필수입니다.")
-            String settingKey,
-
-            @NotNull(message = "설정 값은 필수입니다.")
-            SettingValue settingValue
+            String settingKey
     ) {}
 
 }

--- a/src/main/java/com/example/moamoa_backend/member/service/MemberSettingService.java
+++ b/src/main/java/com/example/moamoa_backend/member/service/MemberSettingService.java
@@ -44,6 +44,14 @@ public class MemberSettingService {
     }
 
     /**
+     * 팝업/튜토리얼 다시 보지 않음 설정
+     */
+    @Transactional
+    public void banPopup(Long memberId, String settingKey) {
+        saveSetting(memberId, settingKey, SettingValue.NEVER_SHOW);
+    }
+
+    /**
      * 팝업/튜토리얼 출력 필요 여부 체크
      */
     @Transactional


### PR DESCRIPTION

## 📌 관련 이슈
- closes #86 

---

## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [ ] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정

---

## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.

기존의 단순 조회 메서드(shouldShowPopup)를 제거하고,
조회 시 데이터가 없으면 SHOWN 상태로 자동 초기화하는
checkAndInitPopup 메서드로 로직을 단일화함.

---

## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.

팝업/튜토리얼을 출력할 때는 항상 조회가 이루어짐 이를 checkAndInitPopup 메서드로 조회하게 되면 자동으로 데이터가 없는 경우에 SHOWN으로 생성을 함.
데이터가 없는 경우에는 팝업 출력이 필요할 것이고 true를 리턴하기 때문에 미리 SHOWN으로 데이터를 생성하는 것.

-> 이 과정을 통해 프론트에서는 팝업/튜토리얼에 대해 사용자가 X 버튼을 누르는 경우 API를 호출하지 않아도되고 다시 보지 않기를 누르는 경우에만 API를 호출해도 됨 


---

## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [ ] 엔티티 변경
- [ ] 연관관계 수정
- [ ] 컬럼 추가/삭제
- [ ] QueryDSL / JPQL 수정
- [ ] 마이그레이션 필요 (DDL 변경)

**변경 내용**
- 

---

## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [x] 기존 API 스펙 변경
- [ ] API 삭제

기존 member/settings 는 key, value를 전달받아 해당 이벤트/팝업/튜토리얼 등에 대해 출력 여부를 결정할 수 있었지만
 members/setting/ban으로 변경되며 key ( 이벤트/팝업/튜토리얼의 제목)을 입력받아 이를 다시 보지 않기 상태로 설정하도록 변경



---

## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [] 없음
- [x] 있음 → 내용: 기존과는 API 의 사용하는 방식이 달라졌기 때문에 이에 맞춰 호출해야 함

---

## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분
- 
-

---

## 📎 참고 자료
ERD, API 문서, Swagger 캡처, 관련 링크 등

---

## ✅ 체크 리스트 

- [ ] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [ ] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 팝업을 영구적으로 숨길 수 있는 기능 추가
  * 팝업 표시 여부를 관리하는 개선된 설정 기능 추가

* **개선 사항**
  * 팝업 표시 관리 로직 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->