### PR TITLE
[Refactor] MemberSetting에서 SHOWN 상태 제거, NEVER_SHOW만 저장하도록 변경

### DIFF
--- a/src/main/java/com/example/moamoa_backend/item/service/HomeService.java
+++ b/src/main/java/com/example/moamoa_backend/item/service/HomeService.java
@@ -43,7 +43,7 @@ public class HomeService {
 		// 만약 Response가 record가 아니라 class면: .getPoint()
 
 		//  다시보지않기 체크했으면 false(팝업 안띄움), 없으면 true(띄움)
-		boolean shouldShowTutorial = memberSettingService.checkAndInitPopup(memberId, TUTORIAL_KEY);
+		boolean shouldShowTutorial = memberSettingService.shouldShowPopup(memberId, TUTORIAL_KEY);
 
 		// EntityGraph로 item까지 함께 로딩 (N+1 방지)
 		List<MemberItem> equippedAll = memberItemRepository.findByMemberIdAndIsEquippedTrue(memberId);

--- a/src/main/java/com/example/moamoa_backend/member/controller/MemberController.java
+++ b/src/main/java/com/example/moamoa_backend/member/controller/MemberController.java
@@ -66,7 +66,7 @@ public class MemberController {
             @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody MemberReqDto.SettingRequest request
     ) {
-        memberSettingService.banPopup(
+        memberSettingService.dismissPopup(
                 Long.parseLong(userDetails.getUsername()),
                 request.settingKey()
         );

--- a/src/main/java/com/example/moamoa_backend/member/enums/SettingValue.java
+++ b/src/main/java/com/example/moamoa_backend/member/enums/SettingValue.java
@@ -1,7 +1,10 @@
 package com.example.moamoa_backend.member.enums;
 
-//
+/**
+ * 회원 설정 값
+ * - 데이터 없음: 팝업 표시
+ * - NEVER_SHOW: 팝업 미표시
+ */
 public enum SettingValue {
-    SHOWN,      // 한 번 봄 (닫기)
-    NEVER_SHOW  // 다시 보지 않기
+    NEVER_SHOW
 }

--- a/src/main/java/com/example/moamoa_backend/member/service/MemberSettingService.java
+++ b/src/main/java/com/example/moamoa_backend/member/service/MemberSettingService.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -23,7 +21,6 @@ public class MemberSettingService {
 
     /**
      * 팝업/튜토리얼 출력 여부를 수정
-     * SHOWN, NEVER_SHOW 선택가능
      */
     @Transactional
     public void saveSetting(Long memberId, String settingKey, SettingValue settingValue) {
@@ -47,29 +44,18 @@ public class MemberSettingService {
      * 팝업/튜토리얼 다시 보지 않음 설정
      */
     @Transactional
-    public void banPopup(Long memberId, String settingKey) {
+    public void dismissPopup(Long memberId, String settingKey) {
         saveSetting(memberId, settingKey, SettingValue.NEVER_SHOW);
     }
 
     /**
      * 팝업/튜토리얼 출력 필요 여부 체크
+     * - 데이터 없음: 표시 (true)
+     * - NEVER_SHOW: 미표시 (false)
      */
-    @Transactional
-    public boolean checkAndInitPopup(Long memberId, String settingKey) {
-        Optional<MemberSetting> settingOpt = memberSettingRepository.findByMemberIdAndSettingKey(memberId, settingKey);
-
-        if (settingOpt.isPresent()) {
-            return settingOpt.get().getSettingValue() != SettingValue.NEVER_SHOW;
-        }
-
-        // 없는경우 팝업을 통해 보여줄 것이기 때문에 SHOWN으로 미리 생성
-        memberSettingRepository.save(
-                MemberSetting.builder()
-                        .member(memberRepository.getReferenceById(memberId))
-                        .settingKey(settingKey)
-                        .settingValue(SettingValue.SHOWN)
-                        .build()
-        );
-        return true;
+    public boolean shouldShowPopup(Long memberId, String settingKey) {
+        return memberSettingRepository.findByMemberIdAndSettingKey(memberId, settingKey)
+                .map(setting -> setting.getSettingValue() != SettingValue.NEVER_SHOW)
+                .orElse(true);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closes #94 

---

## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [ ] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정

---

## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.
- SHOWN과 "데이터 없음"이 동일한 동작을 수행하여 불필요한 상태 제거
- checkAndInitPopup → shouldShowPopup으로 변경
- 데이터 없으면 팝업 표시, NEVER_SHOW만 저장

---

## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.
- 기존: 팝업 첫 노출 시 SHOWN 레코드 생성 → 다시 보지 않기 시 NEVER_SHOW로 업데이트
- 변경: 데이터 없음 = 표시, NEVER_SHOW 레코드 존재 = 미표시
- 불필요한 레코드 생성 제거로 DB 부하 감소


---

## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [ ] 엔티티 변경
- [ ] 연관관계 수정
- [ ] 컬럼 추가/삭제
- [ ] QueryDSL / JPQL 수정
- [x] 마이그레이션 필요 (DDL 변경)

기존 SHOWN 상태 레코드 삭제 필요: DELETE FROM member_setting WHERE setting_value = 'SHOWN';

**변경 내용**
- 

---

## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [] 기존 API 스펙 변경
- [ ] API 삭제





---

## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [x] 없음
- [ ] 있음 → 내용:

---

## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분
- 
-

---

## 📎 참고 자료
ERD, API 문서, Swagger 캡처, 관련 링크 등

---

## ✅ 체크 리스트 

- [ ] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [x] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩터링**
  * 팝업 표시 로직을 단순화했습니다. 설정이 없으면 팝업을 표시하고, '표시 안 함' 설정이 있으면 숨기는 방식으로 변경되었습니다.
  * 설정 옵션을 정리하여 '표시 안 함' 옵션만 남겼습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->