### PR TITLE
[Feat] WalletException에 shortfall 포함 및 구매 실패 응답에 반환

### DIFF
--- a/src/main/java/com/example/moamoa_backend/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/moamoa_backend/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -7,11 +7,13 @@ import com.example.moamoa_backend.global.apiPayload.response.ApiResponse;
 import com.example.moamoa_backend.global.security.jwt.exception.code.JwtErrorCode;
 import com.example.moamoa_backend.item.exception.code.ItemErrorCode;
 import com.example.moamoa_backend.member.exception.code.MemberErrorCode;
+import com.example.moamoa_backend.wallet.exception.WalletException;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Path;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -25,173 +27,191 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
 @Slf4j
 @RestControllerAdvice
 public class GeneralExceptionAdvice {
 
-    /**
-     *   GeneralException 처리
-     */
-    @ExceptionHandler(GeneralException.class)
-    public ResponseEntity<ApiResponse<Void>> handleGeneralException(GeneralException e) {
+	/**
+	 *   GeneralException 처리
+	 */
+	@ExceptionHandler(GeneralException.class)
+	public ResponseEntity<ApiResponse<Void>> handleGeneralException(GeneralException e) {
 
-        return ResponseEntity.status(e.getCode().getStatus())
-                .body(ApiResponse.onFailure(
-                                e.getCode(),
-                                null
-                        )
-                );
-    }
+		return ResponseEntity.status(e.getCode().getStatus())
+			.body(ApiResponse.onFailure(
+					e.getCode(),
+					null
+				)
+			);
+	}
 
-    /**
-     * @CookieValue(required=true) 검증 실패 시 (쿠키 누락)
-     */
-    @ExceptionHandler(MissingRequestCookieException.class)
-    public ResponseEntity<ApiResponse<Void>> handleMissingRequestCookieException(MissingRequestCookieException e) {
+	/**
+	 * walletExcetpion 처리
+	 */
+	@ExceptionHandler(WalletException.class)
+	public ResponseEntity<ApiResponse<Map<String, Integer>>> handleWalletException(WalletException e) {
 
-        log.warn("필수 쿠키 누락: {}", e.getCookieName());
+		Map<String, Integer> result = null;
 
-        return ResponseEntity
-                .status(JwtErrorCode.REFRESH_TOKEN_MISSING.getStatus())
-                .body(ApiResponse.onFailure(JwtErrorCode.REFRESH_TOKEN_MISSING, null));
-    }
+		// 포인트 부족일 때만 shortfall 내려주기
+		if (e.getShortfall() != null) {
+			result = Map.of("shortfall", e.getShortfall());
+		}
 
-    /**
-     * @RequestParam, @PathVariable 등에서 타입 변환 실패할 때 발생
-     * 예) ?scope=AAA (OnboardingUpdateScope로 변환 실패)
-     */
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+		return ResponseEntity.status(e.getCode().getStatus())
+			.body(ApiResponse.onFailure(e.getCode(), result));
+	}
 
-        // scope 파라미터에 대해서만 명시적으로 INVALID_SCOPE로 내려줌
-        if ("scope".equals(e.getName()) && e.getRequiredType() != null && e.getRequiredType().isEnum()) {
-            return ResponseEntity
-                .status(MemberErrorCode.INVALID_SCOPE.getStatus())
-                .body(ApiResponse.onFailure(MemberErrorCode.INVALID_SCOPE, null));
-        }
+	/**
+	 * @CookieValue(required=true) 검증 실패 시 (쿠키 누락)
+	 */
+	@ExceptionHandler(MissingRequestCookieException.class)
+	public ResponseEntity<ApiResponse<Void>> handleMissingRequestCookieException(MissingRequestCookieException e) {
 
-        //  /items?category=... (ItemCategory enum 파싱 실패)
-        if ("category".equals(e.getName())) {
-            return ResponseEntity
-                .status(ItemErrorCode.ITEM_INVALID_CATEGORY.getStatus())
-                .body(ApiResponse.onFailure(ItemErrorCode.ITEM_INVALID_CATEGORY, null));
-        }
+		log.warn("필수 쿠키 누락: {}", e.getCookieName());
 
-        //  /items?type=... (ItemType enum 파싱 실패)
-        if ("type".equals(e.getName())) {
-            return ResponseEntity
-                .status(ItemErrorCode.ITEM_INVALID_TYPE.getStatus())
-                .body(ApiResponse.onFailure(ItemErrorCode.ITEM_INVALID_TYPE, null));
-        }
+		return ResponseEntity
+			.status(JwtErrorCode.REFRESH_TOKEN_MISSING.getStatus())
+			.body(ApiResponse.onFailure(JwtErrorCode.REFRESH_TOKEN_MISSING, null));
+	}
 
-        // scope 외 다른 파라미터 타입 미스매치는 일단 500이 아니라 400으로 내림
-        BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
-        log.warn("Type mismatch: param={}, value={}, requiredType={}",
-            e.getName(), e.getValue(), e.getRequiredType());
+	/**
+	 * @RequestParam, @PathVariable 등에서 타입 변환 실패할 때 발생
+	 * 예) ?scope=AAA (OnboardingUpdateScope로 변환 실패)
+	 */
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
 
-        return ResponseEntity
-            .status(errorCode.getStatus())
-            .body(ApiResponse.onFailure(errorCode, null));
-    }
+		// scope 파라미터에 대해서만 명시적으로 INVALID_SCOPE로 내려줌
+		if ("scope".equals(e.getName()) && e.getRequiredType() != null && e.getRequiredType().isEnum()) {
+			return ResponseEntity
+				.status(MemberErrorCode.INVALID_SCOPE.getStatus())
+				.body(ApiResponse.onFailure(MemberErrorCode.INVALID_SCOPE, null));
+		}
 
-    /**
-     *   예상하지 못한 모든 예외 처리
-     */
-    // 검증/바인딩 실패는 400으로 내려서 필드별 오류를 result에 담는다.
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Map<String, String>>> handleMethodArgumentNotValidException(
-        MethodArgumentNotValidException e) {
+		//  /items?category=... (ItemCategory enum 파싱 실패)
+		if ("category".equals(e.getName())) {
+			return ResponseEntity
+				.status(ItemErrorCode.ITEM_INVALID_CATEGORY.getStatus())
+				.body(ApiResponse.onFailure(ItemErrorCode.ITEM_INVALID_CATEGORY, null));
+		}
 
-        Map<String, String> errors = extractFieldErrors(e.getBindingResult().getFieldErrors());
+		//  /items?type=... (ItemType enum 파싱 실패)
+		if ("type".equals(e.getName())) {
+			return ResponseEntity
+				.status(ItemErrorCode.ITEM_INVALID_TYPE.getStatus())
+				.body(ApiResponse.onFailure(ItemErrorCode.ITEM_INVALID_TYPE, null));
+		}
 
-        return ResponseEntity
-            .status(GeneralErrorCode.METHOD_ARGUMENT_NOT_VALID.getStatus())
-            .body(ApiResponse.onFailure(GeneralErrorCode.METHOD_ARGUMENT_NOT_VALID, errors));
-    }
+		// scope 외 다른 파라미터 타입 미스매치는 일단 500이 아니라 400으로 내림
+		BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+		log.warn("Type mismatch: param={}, value={}, requiredType={}",
+			e.getName(), e.getValue(), e.getRequiredType());
 
-    @ExceptionHandler(BindException.class)
-    public ResponseEntity<ApiResponse<Map<String, String>>> handleBindException(BindException e) {
+		return ResponseEntity
+			.status(errorCode.getStatus())
+			.body(ApiResponse.onFailure(errorCode, null));
+	}
 
-        Map<String, String> errors = extractFieldErrors(e.getBindingResult().getFieldErrors());
+	/**
+	 *   예상하지 못한 모든 예외 처리
+	 */
+	// 검증/바인딩 실패는 400으로 내려서 필드별 오류를 result에 담는다.
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponse<Map<String, String>>> handleMethodArgumentNotValidException(
+		MethodArgumentNotValidException e) {
 
-        return ResponseEntity
-            .status(GeneralErrorCode.BINDING_ERROR.getStatus())
-            .body(ApiResponse.onFailure(GeneralErrorCode.BINDING_ERROR, errors));
-    }
+		Map<String, String> errors = extractFieldErrors(e.getBindingResult().getFieldErrors());
 
-    @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ApiResponse<Map<String, String>>> handleConstraintViolationException(
-        ConstraintViolationException e) {
+		return ResponseEntity
+			.status(GeneralErrorCode.METHOD_ARGUMENT_NOT_VALID.getStatus())
+			.body(ApiResponse.onFailure(GeneralErrorCode.METHOD_ARGUMENT_NOT_VALID, errors));
+	}
 
-        Map<String, String> errors = new LinkedHashMap<>();
-        for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
-            String field = resolveViolationField(violation);
-            String message = violation.getMessage();
-            if (field != null && message != null) {
-                errors.putIfAbsent(field, message);
-            }
-        }
+	@ExceptionHandler(BindException.class)
+	public ResponseEntity<ApiResponse<Map<String, String>>> handleBindException(BindException e) {
 
-        return ResponseEntity
-            .status(GeneralErrorCode.CONSTRAINT_VIOLATION.getStatus())
-            .body(ApiResponse.onFailure(GeneralErrorCode.CONSTRAINT_VIOLATION, errors));
-    }
+		Map<String, String> errors = extractFieldErrors(e.getBindingResult().getFieldErrors());
 
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ApiResponse<Map<String, String>>> handleHttpMessageNotReadableException(
-        HttpMessageNotReadableException e) {
+		return ResponseEntity
+			.status(GeneralErrorCode.BINDING_ERROR.getStatus())
+			.body(ApiResponse.onFailure(GeneralErrorCode.BINDING_ERROR, errors));
+	}
 
-        Map<String, String> errors = new LinkedHashMap<>();
-        Throwable cause = e.getMostSpecificCause();
-        String detailMessage = cause != null ? cause.getMessage() : e.getMessage();
-        if (detailMessage != null) {
-            log.warn("Request body parse error: {}", detailMessage, e);
-        } else {
-            log.warn("Request body parse error", e);
-        }
-        errors.put("body", "요청 본문을 읽을 수 없습니다");
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ApiResponse<Map<String, String>>> handleConstraintViolationException(
+		ConstraintViolationException e) {
 
-        return ResponseEntity
-            .status(GeneralErrorCode.MESSAGE_NOT_READABLE.getStatus())
-            .body(ApiResponse.onFailure(GeneralErrorCode.MESSAGE_NOT_READABLE, errors));
-    }
+		Map<String, String> errors = new LinkedHashMap<>();
+		for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
+			String field = resolveViolationField(violation);
+			String message = violation.getMessage();
+			if (field != null && message != null) {
+				errors.putIfAbsent(field, message);
+			}
+		}
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        BaseErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR;
+		return ResponseEntity
+			.status(GeneralErrorCode.CONSTRAINT_VIOLATION.getStatus())
+			.body(ApiResponse.onFailure(GeneralErrorCode.CONSTRAINT_VIOLATION, errors));
+	}
 
-        log.error("예상치 못한 에러 발생: ", e);
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ApiResponse<Map<String, String>>> handleHttpMessageNotReadableException(
+		HttpMessageNotReadableException e) {
 
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ApiResponse.onFailure(errorCode, null));
-    }
+		Map<String, String> errors = new LinkedHashMap<>();
+		Throwable cause = e.getMostSpecificCause();
+		String detailMessage = cause != null ? cause.getMessage() : e.getMessage();
+		if (detailMessage != null) {
+			log.warn("Request body parse error: {}", detailMessage, e);
+		} else {
+			log.warn("Request body parse error", e);
+		}
+		errors.put("body", "요청 본문을 읽을 수 없습니다");
 
-    // BindingResult의 FieldError 목록을 field -> message로 정리한다.
-    private Map<String, String> extractFieldErrors(List<FieldError> fieldErrors) {
-        Map<String, String> errors = new LinkedHashMap<>();
-        for (FieldError fieldError : fieldErrors) {
-            String field = fieldError.getField();
-            String message = fieldError.getDefaultMessage();
-            if (field != null && message != null) {
-                errors.putIfAbsent(field, message);
-            }
-        }
-        return errors;
-    }
+		return ResponseEntity
+			.status(GeneralErrorCode.MESSAGE_NOT_READABLE.getStatus())
+			.body(ApiResponse.onFailure(GeneralErrorCode.MESSAGE_NOT_READABLE, errors));
+	}
 
-    // ConstraintViolation 경로에서 마지막 노드명을 필드로 사용한다.
-    private String resolveViolationField(ConstraintViolation<?> violation) {
-        String field = null;
-        Path path = violation.getPropertyPath();
-        if (path != null) {
-            for (Path.Node node : path) {
-                if (node.getName() != null) {
-                    field = node.getName();
-                }
-            }
-        }
-        return field != null ? field : "param";
-    }
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+		BaseErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR;
+
+		log.error("예상치 못한 에러 발생: ", e);
+
+		return ResponseEntity
+			.status(errorCode.getStatus())
+			.body(ApiResponse.onFailure(errorCode, null));
+	}
+
+	// BindingResult의 FieldError 목록을 field -> message로 정리한다.
+	private Map<String, String> extractFieldErrors(List<FieldError> fieldErrors) {
+		Map<String, String> errors = new LinkedHashMap<>();
+		for (FieldError fieldError : fieldErrors) {
+			String field = fieldError.getField();
+			String message = fieldError.getDefaultMessage();
+			if (field != null && message != null) {
+				errors.putIfAbsent(field, message);
+			}
+		}
+		return errors;
+	}
+
+	// ConstraintViolation 경로에서 마지막 노드명을 필드로 사용한다.
+	private String resolveViolationField(ConstraintViolation<?> violation) {
+		String field = null;
+		Path path = violation.getPropertyPath();
+		if (path != null) {
+			for (Path.Node node : path) {
+				if (node.getName() != null) {
+					field = node.getName();
+				}
+			}
+		}
+		return field != null ? field : "param";
+	}
 }
 

--- a/src/main/java/com/example/moamoa_backend/wallet/entity/Wallet.java
+++ b/src/main/java/com/example/moamoa_backend/wallet/entity/Wallet.java
@@ -15,40 +15,41 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Wallet extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false, unique = true)
-    private Member member;
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false, unique = true)
+	private Member member;
 
-    @Column(nullable = false)
-    private Integer point;
+	@Column(nullable = false)
+	private Integer point;
 
-    private Wallet(Member member, Integer point) {
-        this.member = member;
-        this.point = point;
-    }
+	private Wallet(Member member, Integer point) {
+		this.member = member;
+		this.point = point;
+	}
 
-    public static Wallet create(Member member) {
-        return new Wallet(member, 0);
-    }
+	public static Wallet create(Member member) {
+		return new Wallet(member, 0);
+	}
 
-    public void addPoint(int amount) {
-        if (amount <= 0) {
-            throw new WalletException(WalletErrorCode.INVALID_AMOUNT);
-        }
-        this.point += amount;
-    }
+	public void addPoint(int amount) {
+		if (amount <= 0) {
+			throw new WalletException(WalletErrorCode.INVALID_AMOUNT);
+		}
+		this.point += amount;
+	}
 
-    public void usePoint(int amount) {
-        if (amount <= 0) {
-            throw new WalletException(WalletErrorCode.INVALID_AMOUNT);
-        }
-        if (this.point < amount) {
-            throw new WalletException(WalletErrorCode.INSUFFICIENT_POINTS);
-        }
-        this.point -= amount;
-    }
+	public void usePoint(int amount) {
+		if (amount <= 0) {
+			throw new WalletException(WalletErrorCode.INVALID_AMOUNT);
+		}
+		if (this.point < amount) {
+			int shortfall = amount - this.point; //  부족분
+			throw new WalletException(WalletErrorCode.INSUFFICIENT_POINTS, shortfall); // 예외에 부족분 포함
+		}
+		this.point -= amount;
+	}
 }

--- a/src/main/java/com/example/moamoa_backend/wallet/exception/WalletException.java
+++ b/src/main/java/com/example/moamoa_backend/wallet/exception/WalletException.java
@@ -3,8 +3,19 @@ package com.example.moamoa_backend.wallet.exception;
 import com.example.moamoa_backend.global.apiPayload.code.BaseErrorCode;
 import com.example.moamoa_backend.global.apiPayload.exception.GeneralException;
 
+import lombok.Getter;
+
+@Getter
 public class WalletException extends GeneralException {
+	private final Integer shortfall; //  추가
+
 	public WalletException(BaseErrorCode code) {
+		this(code, null);
+	}
+
+	public WalletException(BaseErrorCode code, Integer shortfall) {
 		super(code);
+		this.shortfall = shortfall;
 	}
 }
+


### PR DESCRIPTION
## 📌 관련 이슈
- closes #146 

---

## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [ ] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정

---

## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.
- WalletException에 shortfall 포함 및 구매 실패 응답에 반환

---

## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.
- WalletException에 shortfall 포함 및 구매 실패 응답에 반환


---

## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [ ] 엔티티 변경
- [ ] 연관관계 수정
- [ ] 컬럼 추가/삭제
- [ ] QueryDSL / JPQL 수정
- [ ] 마이그레이션 필요 (DDL 변경)

**변경 내용**
- 

---

## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [x] 기존 API 스펙 변경
- [ ] API 삭제

변경 내용

POST /api/v1/members/me/purchases 실패 응답(포인트 부족 시)에 result.shortfall 필드 추가

예)

{
  "isSuccess": false,
  "code": "WALLET_...",
  "message": "...",
  "result": { "shortfall": 120 }
}



---

## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [ ] 없음
- [x] 있음 → 내용: 포인트 부족 실패 응답의 result 스키마가 null → { shortfall }로 변경됨(프론트에서 result 파싱 필요)

---

## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분
- WalletException을 GeneralException보다 우선 처리하는 핸들러 매칭 정상 동작 여부

- 포인트 부족 외 WalletException 케이스에서 result=null 유지되는지

---

## 📎 참고 자료
ERD, API 문서, Swagger 캡처, 관련 링크 등

---

## ✅ 체크 리스트 

- [x] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [x] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 지갑 포인트 부족 시 정확한 부족액 정보가 포함된 상세 오류 메시지 제공
  * 포인트 거래 실패 시 오류 처리 개선으로 더 명확한 피드백 제공

* **기타 개선사항**
  * 지갑 관련 내부 코드 구조 정리 및 예외 처리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->