### PR TITLE
[Refactor] 회원가입 시 성별/생년월일 필드 제거

### DIFF
--- a/src/main/java/com/example/moamoa_backend/auth/dto/req/AuthReqDto.java
+++ b/src/main/java/com/example/moamoa_backend/auth/dto/req/AuthReqDto.java
@@ -52,12 +52,6 @@ public class AuthReqDto {
             @NotBlank(message = "이름은 필수 입력 값입니다.")
             String name,
 
-            @NotNull(message = "생년월일은 필수 입력 값입니다.")
-            LocalDate birth,
-
-            @NotNull(message = "성별은 필수 입력 값입니다.")
-            Gender gender,
-
             @NotNull(message = "약관 동의 내역은 필수입니다.")
             @Size(min = 1, message = "최소 하나 이상의 약관에 동의해야 합니다.")
             @Valid
@@ -69,8 +63,8 @@ public class AuthReqDto {
                     .email(email)
                     .password(passwordEncoder.encode(password))
                     .name(name)
-                    .birthday(birth)
-                    .gender(gender)
+                    .birthday(null)
+                    .gender(null)
                     .role(Role.ROLE_USER)
                     .provider(Provider.LOCAL)
                     .providerId(email)


### PR DESCRIPTION
## 📌 관련 이슈
- closes #157 
---
## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [ ] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정
---
## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.
- 회원가입 Request DTO에서 성별, 생년월일 필드 제거
- toEntity()에서 해당 필드를 명시적으로 null로 설정
---
## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.
- 피그마 가입 플로우 변경에 따라 성별/생년월일을 가입 시 입력받지 않도록 수정
- 두 필드 모두 DB에서 nullable이므로, 가입 시 null 저장 → 이후 개인정보 수정 페이지에서 입력받는 방식으로 전환
---
## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [ ] 엔티티 변경
- [ ] 연관관계 수정
- [ ] 컬럼 추가/삭제
- [ ] QueryDSL / JPQL 수정
- [ ] 마이그레이션 필요 (DDL 변경)
**변경 내용**
- 없음
---
## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [x] 기존 API 스펙 변경
- [ ] API 삭제

- 회원가입 API 호출 시 생년월일과 성별 입력하지 않음

---
## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [ ] 없음
- [x] 있음 → 내용: 회원가입 API 요청 바디에서 gender, birth 필드가 제거됨 (프론트엔드 가입 요청 수정 필요)
---
## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분

---
## 📎 참고 자료

---
## ✅ 체크 리스트 
- [x] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [x] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * 회원가입 시 생년월일 및 성별 정보 입력이 더 이상 필요하지 않습니다. 가입 절차가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->