### PR TITLE
[Feat] 문의 답변 담당자 이름 저장 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/moamoa_backend/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/example/moamoa_backend/inquiry/controller/InquiryController.java
@@ -109,7 +109,8 @@ public class InquiryController {
     ) {
         // ✅ 기존 서비스 시그니처 유지
         InquiryAnswerRequestDto.CreateAnswer request = new InquiryAnswerRequestDto.CreateAnswer(
-                form.answer()
+                form.answer(),
+                form.responderName()
         );
 
         InquiryAnswerResponseDto.CreateResult result =

--- a/src/main/java/com/example/moamoa_backend/inquiry/converter/InquiryDetailConverter.java
+++ b/src/main/java/com/example/moamoa_backend/inquiry/converter/InquiryDetailConverter.java
@@ -23,6 +23,7 @@ public class InquiryDetailConverter {
                 inquiry.getCreatedAt(),
                 inquiry.getAnsweredAt(),
                 inquiry.getAnswer(), // 답변 내용(없으면 null)
+                inquiry.getResponderName(),  //답변 내용(없으면 null)
                 inquiryImageUrls,
                 answerImageUrls
         );

--- a/src/main/java/com/example/moamoa_backend/inquiry/dto/InquiryAnswerFormDTO.java
+++ b/src/main/java/com/example/moamoa_backend/inquiry/dto/InquiryAnswerFormDTO.java
@@ -12,6 +12,7 @@ public class InquiryAnswerFormDTO {
     @Schema(name = "InquiryAnswerCreateForm")
     public record Create(
             @NotBlank @Size(max = 2000) String answer,
+            @NotBlank @Size(max = 30) String responderName,
 
             @Schema(
                     description = "답변 이미지 파일들 (선택, 여러 개 가능)",

--- a/src/main/java/com/example/moamoa_backend/inquiry/dto/InquiryAnswerRequestDto.java
+++ b/src/main/java/com/example/moamoa_backend/inquiry/dto/InquiryAnswerRequestDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 public class InquiryAnswerRequestDto {
     public record CreateAnswer(
             @NotBlank @Size(max = 2000)
-            String answer
+            String answer,
+            @NotBlank @Size(max = 30) String responderName
     ) {}
 }

--- a/src/main/java/com/example/moamoa_backend/inquiry/dto/InquiryDetailResDto.java
+++ b/src/main/java/com/example/moamoa_backend/inquiry/dto/InquiryDetailResDto.java
@@ -15,6 +15,7 @@ public class InquiryDetailResDto {
             LocalDateTime createdAt,
             LocalDateTime answeredAt,
             String answerContent,         // 없으면 null 가능
+            String responderName,         // 없으면 null 가능
 
             List<String> inquiryImageUrls,
             List<String> answerImageUrls

--- a/src/main/java/com/example/moamoa_backend/inquiry/dto/InquiryQueryResDto.java
+++ b/src/main/java/com/example/moamoa_backend/inquiry/dto/InquiryQueryResDto.java
@@ -18,7 +18,9 @@ public class InquiryQueryResDto {
             String title,
             String contentPreview,
             boolean answered,              // 답변완료 여부
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            String responderName,
+            String answerPreview
     ) {}
 
     public record MyInquiryList(

--- a/src/main/java/com/example/moamoa_backend/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/example/moamoa_backend/inquiry/entity/Inquiry.java
@@ -49,6 +49,10 @@ public class Inquiry extends BaseEntity {
     @Column(nullable = false)
     private boolean termsAgreed;
 
+    @Column(name = "responder_name", length = 30)
+    private String responderName;
+
+
     //createdAt = 질문일시
 
     // 질문 이미지

--- a/src/main/java/com/example/moamoa_backend/inquiry/repository/InquiryRepositoryImpl.java
+++ b/src/main/java/com/example/moamoa_backend/inquiry/repository/InquiryRepositoryImpl.java
@@ -48,7 +48,9 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom{
                         inquiry.content,
                         // answered: answeredAt != null 로 판단
                         inquiry.answeredAt.isNotNull(),
-                        inquiry.createdAt
+                        inquiry.createdAt,
+                        inquiry.responderName,
+                        inquiry.answer
                 ))
                 .from(inquiry)
                 .where(

--- a/src/main/java/com/example/moamoa_backend/inquiry/service/command/InquiryCommandServiceImpl.java
+++ b/src/main/java/com/example/moamoa_backend/inquiry/service/command/InquiryCommandServiceImpl.java
@@ -79,6 +79,7 @@ public class InquiryCommandServiceImpl implements InquiryCommandService {
                 .orElseThrow(() -> new InquiryException(InquiryErrorCode.INQUIRY_NOT_FOUND));
 
         inquiry.setAnswer(request.answer());
+        inquiry.setResponderName(request.responderName());
         inquiry.setAnsweredAt(LocalDateTime.now());
         inquiry.setStatus(InquiryStatus.COMPLETED);
 

--- a/src/main/java/com/example/moamoa_backend/inquiry/service/query/InquiryQueryServiceImpl.java
+++ b/src/main/java/com/example/moamoa_backend/inquiry/service/query/InquiryQueryServiceImpl.java
@@ -44,7 +44,9 @@ public class InquiryQueryServiceImpl implements com.example.moamoa_backend.inqui
                         i.title(),
                         toPreview(i.contentPreview(), 40),  // 40자 미리보기
                         i.answered(),
-                        i.createdAt()
+                        i.createdAt(),
+                        i.responderName(),
+                        toPreview(i.answerPreview(), 40)
                 ))
                 .toList();
 
@@ -52,7 +54,7 @@ public class InquiryQueryServiceImpl implements com.example.moamoa_backend.inqui
     }
 
     private String toPreview(String content, int maxLen) {
-        if (content == null) return "";
+        if (content == null) return null;
         String trimmed = content.trim();
         if (trimmed.length() <= maxLen) return trimmed;
         return trimmed.substring(0, maxLen) + "...";

--- a/src/main/resources/db/migration/V10__AddResponderNameToInquiry.sql
+++ b/src/main/resources/db/migration/V10__AddResponderNameToInquiry.sql
@@ -1,0 +1,2 @@
+ALTER TABLE inquiry
+    ADD COLUMN responder_name VARCHAR(30) NULL;


### PR DESCRIPTION
## 📌 관련 이슈
- closes #150 

---

## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [ ] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정

---

## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.

- 문의 답변 시 담당자 이름(responderName)을 저장하도록 기능 추가
- 문의 목록 및 상세 조회 API 응답에 담당자 이름, 답변 미리보기 정보 포함

---

## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.

- 문의 답변 등록 시점에 답변 담당자 이름을 Inquiry 엔티티에 저장하도록 구현
- 답변 대기(WAITING) 상태인 문의는 담당자 이름을 null로 유지하여 도메인 상태를 명확히 표현
- 문의 목록 조회 시 답변 내용은 UI 편의를 위해 미리보기 형태로 가공하여 전달

---

## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [x] 엔티티 변경
- [ ] 연관관계 수정
- [x] 컬럼 추가/삭제
- [x] QueryDSL / JPQL 수정
- [x] 마이그레이션 필요 (DDL 변경)

**변경 내용**
- Inquiry 테이블에 responder_name 컬럼 추가 (Flyway V10)
- Inquiry 엔티티에 responderName 필드 추가
- 문의 목록 조회 QueryDSL projection에 담당자 이름 및 답변 내용 포함

---

## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [x] 기존 API 스펙 변경
- [ ] API 삭제

---

## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [x] 없음
- [ ] 있음 → 내용:

---

## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분
- 답변 대기/완료 상태에 따른 responderName null 처리 방식이 적절한지
- QueryDSL projection과 DTO 필드 매핑이 일관되게 적용되었는지
- 기존 문의 조회 로직에 성능 및 부작용이 없는지

---

## 📎 참고 자료
ERD, API 문서, Swagger 캡처, 관련 링크 등

---

## ✅ 체크 리스트 

- [ ] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [ ] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 문의 답변 작성 시 응답자 이름을 입력할 수 있습니다(최대 30자).
  * 문의 목록 및 상세 화면에서 응답자 이름과 답변 미리보기를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->