### PR TITLE
[Refactor] 회원가입 API 응답에 온보딩 및 정책 동의 여부 필드 추가

### DIFF
--- a/src/main/java/com/example/moamoa_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/moamoa_backend/domain/auth/controller/AuthController.java
@@ -52,13 +52,13 @@ public class AuthController implements AuthControllerDocs {
     @Override
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/signup")
-    public ApiResponse<AuthResDto.TokenDto> signup(
+    public ApiResponse<AuthResDto.LoginResponseDto> signup(
             @RequestBody @Valid AuthReqDto.SignupDto request,
             HttpServletResponse response
     ) {
-        AuthResDto.GeneratedTokenDto generatedTokenDto = authService.signup(request);
-        cookieUtil.setRefreshTokenCookie(response, generatedTokenDto.refreshToken());
-        return ApiResponse.onSuccess(AuthSuccessCode.SIGNUP_SUCCESS, AuthConverter.toTokenDto(generatedTokenDto));
+        AuthResDto.LoginResultDto result = authService.signup(request);
+        cookieUtil.setRefreshTokenCookie(response, result.generatedToken().refreshToken());
+        return ApiResponse.onSuccess(AuthSuccessCode.SIGNUP_SUCCESS, AuthConverter.toLoginResponseDto(result));
     }
 
     @Override

--- a/src/main/java/com/example/moamoa_backend/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/example/moamoa_backend/domain/auth/controller/AuthControllerDocs.java
@@ -100,7 +100,7 @@ public interface AuthControllerDocs {
                     """
     )
     @SecurityRequirements(value = {})
-    ApiResponse<AuthResDto.TokenDto> signup(
+    ApiResponse<AuthResDto.LoginResponseDto> signup(
             @RequestBody @Valid AuthReqDto.SignupDto request,
             HttpServletResponse response
     );

--- a/src/main/java/com/example/moamoa_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/moamoa_backend/domain/auth/service/AuthService.java
@@ -201,7 +201,7 @@ public class AuthService {
      * - 자동 로그인
      */
     @Transactional
-    public AuthResDto.GeneratedTokenDto signup(AuthReqDto.SignupDto request) {
+    public AuthResDto.LoginResultDto signup(AuthReqDto.SignupDto request) {
 
         if (!request.password().equals(request.passwordCheck())) {
             throw new AuthException(AuthErrorCode.PASSWORD_CONFIRM_MISMATCH);
@@ -237,7 +237,11 @@ public class AuthService {
         // 인증 플래그 삭제 (재사용 방지)
         redisUtil.deleteData(VERIFIED_PREFIX + request.email());
 
-        return tokenDto;
+        return AuthResDto.LoginResultDto.builder()
+                .generatedToken(tokenDto)
+                .onboardingCompleted(savedMember.getOnboardingCompleted())
+                .policyAgreed(savedMember.getPolicyAgreed())
+                .build();
     }
 
     /**


### PR DESCRIPTION
## 📌 관련 이슈
- closes #180

---

## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [ ] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정

---

## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.
- AuthService.signup() 반환 타입 GeneratedTokenDto → LoginResultDto 변경
- AuthController.signup() 응답 타입 TokenDto → LoginResponseDto 변경
- AuthControllerDocs signup 시그니처 동기화

---

## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.
- 프론트 라우팅을 위해 로그인과 회원가입 모두 정책 동의 여부와 온보딩 완료 여부를 포함하도록 응답 통일


---

## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [ ] 엔티티 변경
- [ ] 연관관계 수정
- [ ] 컬럼 추가/삭제
- [ ] QueryDSL / JPQL 수정
- [ ] 마이그레이션 필요 (DDL 변경)

**변경 내용**
- 없음

---

## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [x] 기존 API 스펙 변경
- [ ] API 삭제

- 회원가입 응답이 기존 로그인 응답처럼 토큰 정보 이외에 멤버의 컬럼인 온보딩 여부와 정책 동의 여부를 포함함
- 이에 따라 프론트에서 해당 정보 이용해서 라우팅 하도록 수정 예정


---

## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [x] 없음
- [ ] 있음 → 내용:

---

## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분
- 
-

---

## 📎 참고 자료
ERD, API 문서, Swagger 캡처, 관련 링크 등

---

## ✅ 체크 리스트 

- [x] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [x] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 회원가입 API 개선

* **새로운 기능**
  * 회원가입 API 응답에 온보딩 완료 여부와 정책 동의 상태 정보가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->