### PR TITLE
[Refactor] 일별 도토리 내역 응답에 missionId 필드 추가

### DIFF
--- a/src/main/java/com/example/moamoa_backend/domain/wallet/dto/WalletHistoryDayResponseDto.java
+++ b/src/main/java/com/example/moamoa_backend/domain/wallet/dto/WalletHistoryDayResponseDto.java
@@ -11,6 +11,7 @@ public class WalletHistoryDayResponseDto {
             TransactionType type,
             int amount,                 // 도토리 증감(+) 기준
             LocalDateTime occurredAt,    // createdAt
+            Long missionId,
             String missionTitle,         // type==MISSION 일 때만
             Integer missionDurationMinutes // type==MISSION 일 때만
     ) {}

--- a/src/main/java/com/example/moamoa_backend/domain/wallet/service/query/WalletHistoryQueryServiceImpl.java
+++ b/src/main/java/com/example/moamoa_backend/domain/wallet/service/query/WalletHistoryQueryServiceImpl.java
@@ -40,6 +40,7 @@ public class WalletHistoryQueryServiceImpl implements WalletHistoryQueryService{
                                 wh.type,
                                 wh.amount,
                                 wh.createdAt,
+                                m.id,
                                 m.title,
                                 m.durationMinutes
                         )


### PR DESCRIPTION
## 📌 관련 이슈
- closes #186 

---

## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [ ] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정

---

## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.

- 일별 도토리 내역 조회 API 응답에 missionId 필드를 추가하였습니다.

---

## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.
-  WalletHistoryDayResponseDto.Item에 missionId 필드(Long, nullable) 추가


---

## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [ ] 엔티티 변경
- [ ] 연관관계 수정
- [ ] 컬럼 추가/삭제
- [x] QueryDSL / JPQL 수정
- [ ] 마이그레이션 필요 (DDL 변경)

**변경 내용**
- QueryDSL projection에 m.id 추가

---

## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [x] 기존 API 스펙 변경
- [ ] API 삭제





---

## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [x] 없음
- [ ] 있음 → 내용:

---

## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분
- QueryDSL constructor projection 인자 순서와 DTO 정의가 일치하는지 확인 부탁드립니다.

---

## 📎 참고 자료
ERD, API 문서, Swagger 캡처, 관련 링크 등

---

## ✅ 체크 리스트 

- [ ] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [ ] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지갑 거래 내역에 관련 미션 ID 정보가 포함되도록 업데이트되었습니다. 각 거래 기록에서 미션 식별자를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->