### PR TITLE
[Fix] 홈 포켓 미션 수행시간 집계 기준 변경

### DIFF
--- a/src/main/java/com/example/moamoa_backend/domain/item/service/query/MemberHomeQueryServiceImpl.java
+++ b/src/main/java/com/example/moamoa_backend/domain/item/service/query/MemberHomeQueryServiceImpl.java
@@ -87,45 +87,48 @@ public class MemberHomeQueryServiceImpl implements MemberHomeQueryService {
 		LocalDateTime thisWeekStart = thisWeekMon.atStartOfDay();
 		LocalDateTime nextWeekStart = nextWeekMon.atStartOfDay();
 
-		// 2) 오늘/이번주 미션 시청시간 합
-		Long todaySeconds = queryFactory
-			.select(
-				Expressions.numberTemplate(
-					Long.class,
-					"coalesce(sum({0}), 0)",
-						mission.videoLength
+		// 2) 오늘/이번주 미션 수행시간 합 (missionPerformedAt + FAIL/SUCCESS 기준)
+		Long todayMinutes = queryFactory
+				.select(
+						Expressions.numberTemplate(
+								Long.class,
+								"coalesce(sum({0}), 0)",
+								mission.durationMinutes   // ✅ durationMinutes 사용
+						)
 				)
-			)
-			.from(mm)
-			.join(mm.mission, mission)
-			.where(
-				mm.member.id.eq(memberId),
-				mm.createdAt.goe(todayStart),
-				mm.createdAt.lt(tomorrowStart)
-			)
-			.fetchOne();
-
-		Long thisWeekSeconds = queryFactory
-			.select(
-				Expressions.numberTemplate(
-					Long.class,
-					"coalesce(sum({0}), 0)",
-						mission.videoLength
+				.from(mm)
+				.join(mm.mission, mission)
+				.where(
+						mm.member.id.eq(memberId),
+						mm.missionPerformedAt.isNotNull(),
+						mm.missionPerformedAt.goe(todayStart),
+						mm.missionPerformedAt.lt(tomorrowStart),
+						mm.missionStatus.in(MissionStatus.FAIL, MissionStatus.SUCCESS)
 				)
-			)
-			.from(mm)
-			.join(mm.mission, mission)
-			.where(
-				mm.member.id.eq(memberId),
-				mm.createdAt.goe(thisWeekStart),
-				mm.createdAt.lt(nextWeekStart)
-			)
-			.fetchOne();
+				.fetchOne();
 
-		long todayMissionMinutes =
-				(todaySeconds == null ? 0L : todaySeconds) / 60;
-		long thisWeekMissionMinutes =
-				(thisWeekSeconds == null ? 0L : thisWeekSeconds) / 60;
+		Long thisWeekMinutes = queryFactory
+				.select(
+						Expressions.numberTemplate(
+								Long.class,
+								"coalesce(sum({0}), 0)",
+								mission.durationMinutes   // ✅ durationMinutes 사용
+						)
+				)
+				.from(mm)
+				.join(mm.mission, mission)
+				.where(
+						mm.member.id.eq(memberId),
+						mm.missionPerformedAt.isNotNull(),
+						mm.missionPerformedAt.goe(thisWeekStart),
+						mm.missionPerformedAt.lt(nextWeekStart),
+						mm.missionStatus.in(MissionStatus.FAIL, MissionStatus.SUCCESS)
+				)
+				.fetchOne();
+
+		long todayMissionMinutes = todayMinutes == null ? 0L : todayMinutes;
+		long thisWeekMissionMinutes = thisWeekMinutes == null ? 0L : thisWeekMinutes;
+
 
 		// 3) wallet point
 		Integer point = queryFactory


### PR DESCRIPTION
## 📌 관련 이슈
- closes #201 

---

## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [ ] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정

---

## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.

- 홈 포켓(Home Pocket) 미션 수행시간 집계 기준을 createdAt → missionPerformedAt 기준으로 수정
- 미션 수행시간 집계 값을 videoLength → durationMinutes 기준으로 변경
- 수행 시간 집계 시 FAIL, SUCCESS 상태의 미션만 포함하도록 조건 보완

---

## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.

- 미션 수행 시간을 “최초 도전 시점(missionPerformedAt)” 기준으로 집계하도록 변경하여 도전 기반 통계로 개선
- 수행한 미션의 예상 소요 시간(durationMinutes)을 기준으로 시간 계산
- FAIL, SUCCESS 상태만 포함하여 단순 조회/스크랩 등의 상태는 집계에서 제외

---

## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [ ] 엔티티 변경
- [ ] 연관관계 수정
- [ ] 컬럼 추가/삭제
- [x] QueryDSL / JPQL 수정
- [ ] 마이그레이션 필요 (DDL 변경)

**변경 내용**
- 홈 포켓 조회 QueryDSL 집계 조건을 missionPerformedAt 기준으로 변경
- 집계 컬럼을 mission.videoLength → mission.durationMinutes 로 변경

---

## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [x] 기존 API 스펙 변경
- [ ] API 삭제

---

## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [x] 없음
- [ ] 있음 → 내용:

---

## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분
- missionPerformedAt 값이 실제 도전 시점에 정확히 세팅되고 있는지
- FAIL/SUCCESS 상태만 집계하는 로직이 정책 의도와 일치하는지
- durationMinutes 기준 집계가 기존 통계 데이터와 충돌하지 않는지


---

## 📎 참고 자료
ERD, API 문서, Swagger 캡처, 관련 링크 등

---

## ✅ 체크 리스트 

- [ ] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [ ] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 홈 화면의 일일/주간 미션 시청 시간 계산 방식을 개선했습니다. 미션 생성 시간이 아닌 실제 수행 시간을 기준으로 정확하게 집계되도록 수정하여 사용자가 보는 통계가 더 정확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->