### PR TITLE
[Feat] Inquiry 이미지 용량 제한(10MB) 수정

### DIFF
--- a/src/main/java/com/example/moamoa_backend/domain/inquiry/exception/code/InquiryErrorCode.java
+++ b/src/main/java/com/example/moamoa_backend/domain/inquiry/exception/code/InquiryErrorCode.java
@@ -22,6 +22,12 @@ public enum InquiryErrorCode implements BaseErrorCode {
 		"INQUIRY400_2",
 		"답변 이미지는 최대 5개까지 업로드할 수 있습니다."),
 
+	FILE_SIZE_EXCEEDED(
+			HttpStatus.BAD_REQUEST,
+			"INQUIRY400_5",
+			"파일 크기는 10MB를 초과할 수 없습니다."
+	),
+
 	// ============= 403 Forbidden =============
 	TERMS_NOT_AGREED(
 		HttpStatus.FORBIDDEN,

--- a/src/main/java/com/example/moamoa_backend/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/moamoa_backend/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -1,5 +1,6 @@
 package com.example.moamoa_backend.global.apiPayload.handler;
 
+import com.example.moamoa_backend.domain.inquiry.exception.code.InquiryErrorCode;
 import com.example.moamoa_backend.global.apiPayload.code.BaseErrorCode;
 import com.example.moamoa_backend.global.apiPayload.code.GeneralErrorCode;
 import com.example.moamoa_backend.global.apiPayload.exception.GeneralException;
@@ -14,6 +15,7 @@ import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Path;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -250,4 +253,19 @@ public class GeneralExceptionAdvice {
 		}
 		return field != null ? field : "param";
 	}
+
+	@ExceptionHandler(MaxUploadSizeExceededException.class)
+	public ResponseEntity<ApiResponse<Void>> handleMaxSizeException(
+			MaxUploadSizeExceededException e) {
+
+		return ResponseEntity
+				.status(HttpStatus.BAD_REQUEST)
+				.body(ApiResponse.onFailure(
+						InquiryErrorCode.FILE_SIZE_EXCEEDED,
+						null
+				));
+	}
 }
+
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,12 @@ spring:
   application:
     name: MOAMOA_Backend
 
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 50MB
+
 #==============Flyway==============
   flyway:
     enabled: true


### PR DESCRIPTION
## 📌 관련 이슈
- closes #210 

---

## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [x] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정

---

## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.

- 이미지 업로드 최대 용량을 10MB로 제한하도록 multipart 설정을 추가/수정했습니다.

- 업로드 파일 용량 초과 시(10MB 초과) 전역 예외 처리로 도메인 에러코드 응답을 반환하도록 처리했습니다.

---

## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.

- spring.servlet.multipart.max-file-size, max-request-size 설정으로 업로드 용량 제한 적용

- MaxUploadSizeExceededException 발생 시 GeneralExceptionAdvice에서 캐치하여 InquiryErrorCode.FILE_SIZE_EXCEEDED로 응답 반환


---

## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [ ] 엔티티 변경
- [ ] 연관관계 수정
- [ ] 컬럼 추가/삭제
- [ ] QueryDSL / JPQL 수정
- [ ] 마이그레이션 필요 (DDL 변경)

**변경 내용**
- 

---

## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [ ] 기존 API 스펙 변경
- [ ] API 삭제





---

## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [ ] 없음
- [x] 있음 → 내용: 이미지 업로드가 10MB 초과 시 실패(에러코드 반환) 하도록 정책이 명확히 적용됨

---

## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분
- 전역 예외 처리에서 MaxUploadSizeExceededException → InquiryErrorCode.FILE_SIZE_EXCEEDED 매핑이 의도대로 동작하는지 확인 부탁드립니다.

---

## 📎 참고 자료
ERD, API 문서, Swagger 캡처, 관련 링크 등

---

## ✅ 체크 리스트 

- [ ] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [ ] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 파일 업로드 시 최대 크기 제한(10MB)이 적용되었습니다.
  * 요청 크기 제한(50MB)이 설정되었습니다.
  * 파일 크기 초과 시 사용자에게 명확한 오류 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->