### PR TITLE
[Feat] 탈퇴 회원 개인정보 익명화 처리 구현

### DIFF
--- a/src/main/java/com/example/moamoa_backend/MoamoaBackendApplication.java
+++ b/src/main/java/com/example/moamoa_backend/MoamoaBackendApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 public class MoamoaBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/moamoa_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/example/moamoa_backend/domain/member/entity/Member.java
@@ -226,6 +226,18 @@ public class Member extends BaseEntity {
 		this.gender = gender;
 	}
 
+    public void anonymize() {
+        this.email = null;
+        this.password = null;
+        this.name = "탈퇴회원";
+        this.providerId = "DELETED_" + this.id;
+        this.phoneNumber = null;
+        this.gender = null;
+        this.birthday = null;
+        this.status = MemberStatus.ANONYMIZED;
+        this.turnOffGoals();
+    }
+
 	/**
 	 * (레거시) 월요일에만 전체 목표(daily+weekly)를 한 번에 적용할 때 사용.
 	 * startDate는 반드시 월요일이어야 한다.

--- a/src/main/java/com/example/moamoa_backend/domain/member/enums/MemberStatus.java
+++ b/src/main/java/com/example/moamoa_backend/domain/member/enums/MemberStatus.java
@@ -4,4 +4,5 @@ public enum MemberStatus {
 	ACTIVE,
 	WITHDRAWN,
 	BANNED,
+    ANONYMIZED
 }

--- a/src/main/java/com/example/moamoa_backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/moamoa_backend/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.example.moamoa_backend.domain.member.repository;
 
 import com.example.moamoa_backend.domain.member.entity.Member;
+import com.example.moamoa_backend.domain.member.enums.MemberStatus;
 import com.example.moamoa_backend.domain.member.enums.Provider;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,6 +21,7 @@ import jakarta.persistence.LockModeType;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
+    List<Member> findByStatusAndDeletedAtBefore(MemberStatus status, LocalDateTime dateTime);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("select m from Member m where m.id = :memberId")

--- a/src/main/java/com/example/moamoa_backend/domain/member/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/com/example/moamoa_backend/domain/member/scheduler/MemberCleanupScheduler.java
@@ -3,18 +3,22 @@ package com.example.moamoa_backend.domain.member.scheduler;
 import com.example.moamoa_backend.domain.member.entity.Member;
 import com.example.moamoa_backend.domain.member.enums.MemberStatus;
 import com.example.moamoa_backend.domain.member.repository.MemberRepository;
+import com.example.moamoa_backend.domain.member.service.MemberAnonymizationService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MemberCleanupScheduler {
 
     private final MemberRepository memberRepository;
+    private final MemberAnonymizationService memberAnonymizationService;
 
     @Scheduled(cron = "0 1 0 * * *", zone = "Asia/Seoul")
     public void anonymizeWithdrawnMembers() {
@@ -24,8 +28,11 @@ public class MemberCleanupScheduler {
         );
 
         for (Member member : members) {
-            member.anonymize();
+            try {
+                memberAnonymizationService.anonymizeOne(member.getId());
+            } catch (Exception e) {
+                log.error("회원 익명화 실패: memberId={}", member.getId(), e);
+            }
         }
     }
-
 }

--- a/src/main/java/com/example/moamoa_backend/domain/member/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/com/example/moamoa_backend/domain/member/scheduler/MemberCleanupScheduler.java
@@ -1,0 +1,31 @@
+package com.example.moamoa_backend.domain.member.scheduler;
+
+import com.example.moamoa_backend.domain.member.entity.Member;
+import com.example.moamoa_backend.domain.member.enums.MemberStatus;
+import com.example.moamoa_backend.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MemberCleanupScheduler {
+
+    private final MemberRepository memberRepository;
+
+    @Scheduled(cron = "0 1 0 * * *", zone = "Asia/Seoul")
+    public void anonymizeWithdrawnMembers() {
+        List<Member> members = memberRepository.findByStatusAndDeletedAtBefore(
+                MemberStatus.WITHDRAWN,
+                LocalDateTime.now().minusDays(30)
+        );
+
+        for (Member member : members) {
+            member.anonymize();
+        }
+    }
+
+}

--- a/src/main/java/com/example/moamoa_backend/domain/member/service/MemberAnonymizationService.java
+++ b/src/main/java/com/example/moamoa_backend/domain/member/service/MemberAnonymizationService.java
@@ -1,20 +1,35 @@
 package com.example.moamoa_backend.domain.member.service;
 
 import com.example.moamoa_backend.domain.member.entity.Member;
+import com.example.moamoa_backend.domain.member.enums.MemberStatus;
 import com.example.moamoa_backend.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MemberAnonymizationService {
 
     private final MemberRepository memberRepository;
 
     @Transactional
     public void anonymizeOne(Long memberId) {
-        memberRepository.findById(memberId)
-                .ifPresent(Member::anonymize);
+        Member member = memberRepository.findById(memberId).orElse(null);
+
+        if (member == null) {
+            log.warn("익명화 대상 회원 없음: memberId={}", memberId);
+            return;
+        }
+
+        if (member.getStatus() != MemberStatus.WITHDRAWN) {
+            log.info("익명화 건너뜀 (상태 변경됨): memberId={}, status={}", memberId, member.getStatus());
+            return;
+        }
+
+        member.anonymize();
+        log.info("회원 익명화 완료: memberId={}", memberId);
     }
 }

--- a/src/main/java/com/example/moamoa_backend/domain/member/service/MemberAnonymizationService.java
+++ b/src/main/java/com/example/moamoa_backend/domain/member/service/MemberAnonymizationService.java
@@ -1,0 +1,20 @@
+package com.example.moamoa_backend.domain.member.service;
+
+import com.example.moamoa_backend.domain.member.entity.Member;
+import com.example.moamoa_backend.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberAnonymizationService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void anonymizeOne(Long memberId) {
+        memberRepository.findById(memberId)
+                .ifPresent(Member::anonymize);
+    }
+}

--- a/src/main/java/com/example/moamoa_backend/global/config/SchedulingConfig.java
+++ b/src/main/java/com/example/moamoa_backend/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.example.moamoa_backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}


### PR DESCRIPTION
## 📌 관련 이슈
- closes #215 
---
## 🧩 변경 유형
해당되는 항목에 체크해주세요.
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 🧪 테스트 코드 추가/수정
- [] 🔧 설정 / 빌드 / 의존성 변경
- [ ] 📝 문서 수정
---
## 📝 변경 내용 요약
이번 PR에서 변경된 내용을 간략히 설명해주세요.
- 탈퇴(WITHDRAWN) 후 30일 경과한 회원의 개인정보를 익명화하는 스케줄러 구현
- MemberStatus에 ANONYMIZED 상태 추가
- @EnableScheduling을 Application에서 별도 SchedulingConfig로 분리
---
## 🏗 주요 구현 사항
> 핵심 로직, 설계 결정, 트레이드오프 등을 적어주세요.
- CASCADE DELETE 대신 익명화 방식 채택 (연관 데이터가 많아 물리 삭제 시 정합성 문제 발생 가능)
- 매일 00:01(KST)에 스케줄러 실행, WITHDRAWN 상태 + deletedAt이 30일 이상 경과한 회원 대상
- email, password, name, providerId, phoneNumber, gender, birthday 익명화 처리
- 익명화 후 status를 ANONYMIZED로 변경하여 중복 처리 방지
---
## 🗄️ DB / JPA 관련 변경
해당 사항이 있다면 체크 및 작성해주세요.
- [x] 엔티티 변경
- [ ] 연관관계 수정
- [ ] 컬럼 추가/삭제
- [ ] QueryDSL / JPQL 수정
- [ ] 마이그레이션 필요 (DDL 변경)
**변경 내용**
- Member 엔티티에 anonymize() 메서드 추가
- MemberStatus enum에 ANONYMIZED 추가
- MemberRepository에 findByStatusAndDeletedAtBefore 쿼리 메서드 추가
---
## 🌐 API 변경 사항
- [ ] 신규 API 추가
- [ ] 기존 API 스펙 변경
- [ ] API 삭제
---
## 🚨 Breaking Change
> 기존 기능에 영향을 주는 변경이 있다면 반드시 작성
- [x] 없음
- [ ] 있음 → 내용:
---
## 🔍 리뷰 포인트
리뷰어가 중점적으로 봐주었으면 하는 부분
- 익명화 대상 컬럼이 충분한지 (개인정보 누락 여부)
---
## 📎 참고 자료
ERD, API 문서, Swagger 캡처, 관련 링크 등
---
## ✅ 체크 리스트 
- [x] CodeRabbit 코멘트 확인/반영(또는 근거 작성)
- [ ] 페어 리뷰어 승인 완료
- [x] 로컬/CI 테스트 통과(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 탈퇴한 회원의 개인정보(이메일, 비밀번호, 전화번호, 성별, 생년월일 등)가 30일 경과 후 자동으로 익명화됩니다.
  * 익명화 시 회원명은 탈퇴 표기로 변경되고, 관련 활동 목표는 비활성화됩니다.
  * 익명화 작업이 매일 새벽(Asia/Seoul 기준 00:01)에 자동 실행됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->